### PR TITLE
Use defer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ func main() {
 	err, runtime := dotnet.NewRuntime(dotnet.RuntimeParams{
 		Properties:                  properties,
 	})
+	defer runtime.Shutdown()
 
 	if err != nil {
 		fmt.Println("Something bad happened! :(")
@@ -50,8 +51,6 @@ func main() {
 
     // this will call HelloWorld.HelloWorld.Hello :)
 	SayHello()
-
-	runtime.Shutdown()
 }
 ```
 

--- a/examples/http.go
+++ b/examples/http.go
@@ -28,6 +28,7 @@ func main() {
 		Properties:                  properties,
 		ManagedAssemblyAbsolutePath: "HelloWorldMain.Exe",
 	})
+	defer runtime.Shutdown()
 
 	if err != nil {
 		fmt.Println("Something bad happened! :(")
@@ -43,6 +44,4 @@ func main() {
 	})
 
 	http.ListenAndServe(":5000", nil)
-
-	runtime.Shutdown()
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -26,6 +26,7 @@ func main() {
 		Properties:                  properties,
 		ManagedAssemblyAbsolutePath: "HelloWorldMain.Exe",
 	})
+	defer runtime.Shutdown()
 
 	if err != nil {
 		fmt.Println("Something bad happened! :(")
@@ -52,6 +53,4 @@ func main() {
 	for {
 
 	}
-
-	runtime.Shutdown()
 }


### PR DESCRIPTION
I'm not sure about this one since maybe it's about personal taste but I think it's good practice to use defer to ensure `Shutdown()` will be called when the current function returns.

If you don't know about `defer`, you can know more:
- https://golang.org/doc/effective_go.html#defer
- https://blog.golang.org/defer-panic-and-recover
